### PR TITLE
cleanup uber specific suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2021-06-03
+
+- Remove guidance on atomics.
+- Remove guidance on unexported global _ prefix.
+- Remove guidance in naked parameters suggesting C-style comments.
+
 # 2021-04-19
 
 - Programs should exit only in `main()`, preferably at most once.


### PR DESCRIPTION
Atomics, global _ prefixes, and C-style param comments were agreed to be
apocryphal, so they have been purged. Use of custom types instead of
naked parameters was kept.